### PR TITLE
[LaraPackagePort] Analyse for Laravel 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,12 @@
     ],
     "require": {
         "php": "^7.0",
-        "illuminate/support": "^5.3",
+        "illuminate/support": "^5.3|~5.5.x-dev",
         "spatie/twitter-streaming-api": "^1.0.0"
     },
     "require-dev": {
-
-        "phpunit/phpunit": "5.*",
-        "orchestra/testbench": "^3.3"
+        "phpunit/phpunit": "^6.2",
+        "orchestra/testbench": "^3.3|~3.5.x-dev"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
     ],
     "require": {
         "php": "^7.0",
-        "illuminate/support": "^5.3|~5.5.x-dev",
+        "illuminate/support": "^5.3|~5.5.x-dev|~5.5.x-dev",
         "spatie/twitter-streaming-api": "^1.0.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.2",
-        "orchestra/testbench": "^3.3|~3.5.x-dev"
+        "orchestra/testbench": "^3.3|~3.5.x-dev|~3.5.x-dev"
     },
     "autoload": {
         "psr-4": {
@@ -51,3 +51,4 @@
         }
     }
 }
+


### PR DESCRIPTION
This Pull-Requests help you to prepare your Package for Laravel 5.5. I've tested it automated and this was the PHPUnit Result:
PHPUnit 6.3-dev by Sebastian Bergmann and contributors.

Runtime:       PHP 7.1.7 with Xdebug 2.5.5
Configuration: /Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-twitter-streaming-api/phpunit.xml.dist

..                                                                  2 / 2 (100%)

Time: 1.15 seconds, Memory: 10.00MB

OK (2 tests, 2 assertions)

Generating code coverage report in Clover XML format ... done

Generating code coverage report in HTML format ... done

Nice looks really good! There are no Errors so it might work in Laravel 5.5 without any adjustments