### PR TITLE
fix to work on PHP 7.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^7.0",
         "illuminate/support": "^5.3",
-        "spatie/twitter-streaming-api": "^1.0.0"
+        "spatie/twitter-streaming-api": "^1.0.1"
     },
     "require-dev": {
 


### PR DESCRIPTION
version 1.0 creates issue:

at /var/www/vendor/fennb/phirehose/lib/Phirehose.php:617
    613|       if ( ($this->method == self::METHOD_FILTER || $this->method == self::METHOD_SITE)
    614|             && count($this->followIds) > 0) {
    615|         $requestParams['follow'] = implode(',', $this->followIds);
    616|       }
  > 617|       if ($this->method == self::METHOD_FILTER && count($this->locationBoxes) > 0) {
    618|         $requestParams['locations'] = implode(',', $this->locationBoxes);
    619|       }
    620|       if ($this->count <> 0) {
    621|         $requestParams['count'] = $this->count;    
version 1.0.1 its supposted to fix that bug