### PR TITLE
Added phpDocBlocks for TwitterStreamingApiFacade and fixed accessor class reference

### DIFF
--- a/src/TwitterStreamingApiFacade.php
+++ b/src/TwitterStreamingApiFacade.php
@@ -5,7 +5,10 @@ namespace Spatie\LaravelTwitterStreamingApi;
 use Illuminate\Support\Facades\Facade;
 
 /**
- * @see \Spatie\LaravelTwitterStreamingApi\LaravelTwitterStreamingApiClass
+ * @method static \Spatie\TwitterStreamingApi\PublicStream publicStream()
+ * @method static \Spatie\TwitterStreamingApi\UserStream userStream()
+ *
+ * @see \Spatie\LaravelTwitterStreamingApi\TwitterStreamingApi
  */
 class TwitterStreamingApiFacade extends Facade
 {


### PR DESCRIPTION
I took the liberty to fix the phpDocBlocks for the TwitterStreamingApiFacade.

Ain't much but it's honest work.