### PR TITLE
Fix unauthorized error due to params order

### DIFF
--- a/src/TwitterStreamingApi.php
+++ b/src/TwitterStreamingApi.php
@@ -19,9 +19,9 @@ class TwitterStreamingApi
     public function publicStream(): PublicStream
     {
         return new PublicStream(
+            $this->config['bearer_token'],
             $this->config['api_key'],
-            $this->config['api_secret_key'],
-            $this->config['bearer_token']
+            $this->config['api_secret_key']
         );
     }
 
@@ -29,9 +29,9 @@ class TwitterStreamingApi
     {
         return new UserStream(
             $this->config['handle'],
+            $this->config['bearer_token'],
             $this->config['api_key'],
-            $this->config['api_secret_key'],
-            $this->config['bearer_token']
+            $this->config['api_secret_key']
         );
     }
 }


### PR DESCRIPTION
Took me an hour to figure why there was an unauthorized error despite having correct config. Found the bug. This is the patch for it.